### PR TITLE
Organize code and add new DISABLE_SETUP configuration option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,9 +77,9 @@ And set your bots::
                                  # apps contain telegrambot.py files that cannot be successfully
                                  # imported.
 
-            'DISABLE_SETUP': True, # If set to false, there will be no tries to set webhook or read
-                                   # updates from the telegram server on app's start
-                                   # (useful when developing on local machine; makes django's startup faster)
+            'DISABLE_SETUP': False, # If set to True, there will be no tries to set webhook or read
+                                    # updates from the telegram server on app's start
+                                    # (useful when developing on local machine; makes django's startup faster)
 
             'BOT_MODULE_NAME': 'telegrambot_handlers', #(Optional [str])  # The default name for file name containing telegram handlers which has to be placed inside your local app(s). Default is 'telegrambot'. Example is to put "telegrambot_handlers.py" file to local app's folder.
 

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,8 @@ And set your bots::
 
             'BOTS' : [
                 {
+                   'ID': 'MainBot', #Unique identifier for your bot (used in your code only)
+
                    'TOKEN': '123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11', #Your bot token.
 
                    #'CONTEXT': True,  # Use context based handler functions
@@ -184,6 +186,7 @@ Then use it in a project creating a module ``telegrambot.py`` in your app ::
             # Default dispatcher (this is related to the first bot in settings.DJANGO_TELEGRAMBOT['BOTS'])
             dp = DjangoTelegramBot.dispatcher
             # To get Dispatcher related to a specific bot
+            # dp = DjangoTelegramBot.getDispatcher('BOT_n_id')        #get by bot identifier
             # dp = DjangoTelegramBot.getDispatcher('BOT_n_token')     #get by bot token
             # dp = DjangoTelegramBot.getDispatcher('BOT_n_username')  #get by bot username
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ django-telegrambot
 
 .. image:: https://img.shields.io/badge/Donate-PayPal-green.svg
     :target: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=LMXQVQ3YA2JJQ
-    
+
 .. image:: http://pepy.tech/badge/django-telegrambot
     :target: http://pepy.tech/count/django-telegrambot
 
@@ -77,6 +77,10 @@ And set your bots::
                                  # apps contain telegrambot.py files that cannot be successfully
                                  # imported.
 
+            'DISABLE_SETUP': True, # If set to false, there will be no tries to set webhook or read
+                                   # updates from the telegram server on app's start
+                                   # (useful when developing on local machine; makes django's startup faster)
+
             'BOT_MODULE_NAME': 'telegrambot_handlers', #(Optional [str])  # The default name for file name containing telegram handlers which has to be placed inside your local app(s). Default is 'telegrambot'. Example is to put "telegrambot_handlers.py" file to local app's folder.
 
             'BOTS' : [
@@ -104,7 +108,7 @@ And set your bots::
         		                   #delivery, 1-100. Defaults to 40. Use lower values to limit the
         		                   #load on your bot's server, and higher values to increase your
         		                   #bot's throughput.
-                    
+
                    # 'MESSAGEQUEUE_ENABLED':(Optinal[bool]), # Make this True if you want to use messagequeue
 
                    # 'MESSAGEQUEUE_ALL_BURST_LIMIT':(Optional[int]), # If not provided 29 is the default value

--- a/django_telegrambot/apps.py
+++ b/django_telegrambot/apps.py
@@ -70,7 +70,7 @@ class DjangoTelegramBot(AppConfig):
 
 
     @classmethod
-    def getBotById(cls, bot_id=None, safe=True):
+    def _get_bot_by_id(cls, bot_id=None, safe=True):
         if bot_id is None:
             return list(cls.bots_data.values())[0]
         else:
@@ -92,7 +92,7 @@ class DjangoTelegramBot(AppConfig):
 
     @classmethod
     def get_dispatcher(cls, bot_id=None, safe=True):
-        bot = cls.getBotById(bot_id, safe)
+        bot = cls._get_bot_by_id(bot_id, safe)
         if bot:
             return bot['dispatcher']
         else:
@@ -106,7 +106,7 @@ class DjangoTelegramBot(AppConfig):
 
     @classmethod
     def get_bot(cls, bot_id=None, safe=True):
-        bot = cls.getBotById(bot_id, safe)
+        bot = cls._get_bot_by_id(bot_id, safe)
         if bot:
             return bot['bot']
         else:
@@ -120,7 +120,7 @@ class DjangoTelegramBot(AppConfig):
 
     @classmethod
     def get_updater(cls, bot_id=None, safe=True):
-        bot = cls.getBotById(bot_id, safe)
+        bot = cls._get_bot_by_id(bot_id, safe)
         if bot:
             return bot['updater']
         else:

--- a/django_telegrambot/apps.py
+++ b/django_telegrambot/apps.py
@@ -55,7 +55,7 @@ class DjangoTelegramBot(AppConfig):
             bot_data = cls.bots_data[0]
             cls.__used_tokens.add(bot_data['token'])
             return bot_data['dispatcher']
-        except StopIteration:
+        except (StopIteration, IndexError):
             raise ReferenceError("No bots are defined")
 
     @classproperty
@@ -65,14 +65,17 @@ class DjangoTelegramBot(AppConfig):
             bot_data = cls.bots_data[0]
             cls.__used_tokens.add(bot_data['token'])
             return bot_data['updater']
-        except StopIteration:
+        except (StopIteration, IndexError):
             raise ReferenceError("No bots are defined")
 
 
     @classmethod
     def _get_bot_by_id(cls, bot_id=None, safe=True):
         if bot_id is None:
-            return cls.bots_data[0]
+            try:
+                return cls.bots_data[0]
+            except IndexError:
+                return None
         else:
             try:
                 bot = next(filter(lambda bot: bot['token'] == bot_id, cls.bots_data))

--- a/django_telegrambot/bot.py
+++ b/django_telegrambot/bot.py
@@ -1,0 +1,25 @@
+from telegram import Bot
+from telegram.ext import Dispatcher, Updater
+
+
+class BotData:
+    def __init__(self,
+                 token,
+                 *,
+                 unique_id=None,
+                 use_context=False,
+                 allowed_updates=None,
+                 timeout=None,
+                 proxy=None,
+                 instance: Bot = None,
+                 dispatcher: Dispatcher = None,
+                 updater: Updater = None):
+        self.token = token
+        self.unique_id = unique_id
+        self.use_context = use_context
+        self.allowed_updates = allowed_updates
+        self.timeout = timeout
+        self.proxy = proxy
+        self.instance = instance
+        self.dispatcher = dispatcher
+        self.updater = updater

--- a/django_telegrambot/views.py
+++ b/django_telegrambot/views.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 @staff_member_required
 def home(request):
-    bot_list = [bot['bot'] for bot in DjangoTelegramBot.bots_data]
+    bot_list = [bot.instance for bot in DjangoTelegramBot.bots_data]
     context = {'bot_list': bot_list, 'update_mode':settings.DJANGO_TELEGRAMBOT.get('MODE', 'WEBHOOK')}
     return render(request, 'django_telegrambot/index.html', context)
 

--- a/django_telegrambot/views.py
+++ b/django_telegrambot/views.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 @staff_member_required
 def home(request):
-    bot_list = DjangoTelegramBot.bots
+    bot_list = [bot['bot'] for bot in DjangoTelegramBot.bots_data]
     context = {'bot_list': bot_list, 'update_mode':settings.DJANGO_TELEGRAMBOT.get('MODE', 'WEBHOOK')}
     return render(request, 'django_telegrambot/index.html', context)
 

--- a/sampleproject/bot/views.py
+++ b/sampleproject/bot/views.py
@@ -4,6 +4,6 @@ from django_telegrambot.apps import DjangoTelegramBot
 
 # Create your views here.
 def index(request):
-    bot_list = DjangoTelegramBot.bots
+    bot_list = [bot['bot'] for bot in DjangoTelegramBot.bots_data]
     context = {'bot_list': bot_list, 'update_mode':settings.DJANGO_TELEGRAMBOT['MODE']}
     return render(request, 'bot/index.html', context)

--- a/sampleproject/bot/views.py
+++ b/sampleproject/bot/views.py
@@ -4,6 +4,6 @@ from django_telegrambot.apps import DjangoTelegramBot
 
 # Create your views here.
 def index(request):
-    bot_list = [bot['bot'] for bot in DjangoTelegramBot.bots_data]
+    bot_list = [bot.instance for bot in DjangoTelegramBot.bots_data]
     context = {'bot_list': bot_list, 'update_mode':settings.DJANGO_TELEGRAMBOT['MODE']}
     return render(request, 'bot/index.html', context)


### PR DESCRIPTION
This PR will organize how this app stores bot data internally; adds an 'ID' attribute to each bot to identify bots with something other than username/token (this makes changing token and username bot easy without changes to the code).

This also adds the DISABLE_SETUP config option which disables setting webhook on each run, and it's useful when you're developing on your local machine and don't want to go through a 5-sec delay that setting webhook causes or when Telegram is blocked in your country.